### PR TITLE
Update index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,11 +3,11 @@ The DeepChem Project
 
 .. raw:: html
 
-  <embed>
-    <a href="https://github.com/deepchem/deepchem">
-      <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png">
-    </a>
-  </embed>
+  <a href="https://github.com/deepchem/deepchem">
+    <img style="position: absolute; top: 0; right: 0; border: 0;" 
+         src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" 
+         alt="Fork me on GitHub">
+  </a>
 
 
 **The DeepChem project aims to democratize deep learning for science.**


### PR DESCRIPTION
Fix broken GitHub ribbon image in index.rst

Description
Fixes #<issue_number> (e.g., #1234)

This PR fixes the broken GitHub ribbon image link in docs/index.rst. The image source URL was either outdated, incorrect, or not rendering properly. The updated link ensures the ribbon appears correctly on the documentation homepage.

Type of change
Please check the option that is related to your PR.

 Documentations (modification for documents)

Checklist
 My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)

 Run yapf -i <modified file> and check no errors (yapf version must be 0.32.0)

 Run mypy -p deepchem and check no errors

 Run flake8 <modified file> --count and check no errors

 Run python -m doctest <modified file> and check no errors

 I have performed a self-review of my own code

 I have commented my code, particularly in hard-to-understand areas

 I have made corresponding changes to the documentation

 I have added tests that prove my fix is effective or that my feature works (not applicable)

 New unit tests pass locally with my changes (if applicable)

 I have checked my code and corrected any misspellings
